### PR TITLE
fix #38 : python lib crashed

### DIFF
--- a/pypolodb/polodb_ext.c
+++ b/pypolodb/polodb_ext.c
@@ -266,8 +266,8 @@ static PyObject* CollectionObject_new(PyTypeObject* type, PyObject* args, PyObje
 static int CollectionObject_init(CollectionObject* self, PyObject* args, PyObject* kwds) {
   PyObject* db_obj;
   const char* name;
-  uint32_t col_id = 0;
-  uint32_t meta_version = 0;
+  unsigned long col_id = 0;
+  unsigned long meta_version = 0;
   if (!PyArg_ParseTuple(args, "Oskk", &db_obj, &name, &col_id, &meta_version)) {
     return -1;
   }

--- a/pypolodb/setup.py
+++ b/pypolodb/setup.py
@@ -100,7 +100,7 @@ module1 = Extension('polodb',
 long_description = ''
 
 setup (name = 'polodb',
-       version = '0.10.0',
+       version = '0.10.1',
        description = 'PoloDB for Python',
        long_description=long_description,
        long_description_content_type="text/markdown",


### PR DESCRIPTION
- unsigned long is 8 bytes wide, but the pointer is uint32_t(which is 4 bytes)
- only crashes on Linux