### PR TITLE
fix: CI error on Windows

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,9 +21,9 @@ jobs:
           node-version: '14'
       
       - name: Run Rust tests
-        run: |
-          cargo test --release --verbose --workspace
-          cargo build --release --package polodb_clib
+        run: cargo test --release --verbose --workspace
+      - name: Build Clib
+        run: cargo build --release --package polodb_clib
 
   Windows:
     name: Test on Windows
@@ -35,6 +35,6 @@ jobs:
           node-version: '14'
 
       - name: Run Rust tests
-        run: |
-          cargo test --release --verbose --workspace
-          cargo build --release --package polodb_clib
+        run: cargo test --release --verbose --workspace
+      - name: Build Clib
+        run: cargo build --release --package polodb_clib

--- a/src/polodb/Cargo.toml
+++ b/src/polodb/Cargo.toml
@@ -11,7 +11,6 @@ path = "main.rs"
 
 [dependencies]
 polodb_core = { path = "../polodb_core" }
-polodb_bson = "2.0.0"
 byteorder = "1.4.3"
 clap = "2.33.3"
 chrono = "0.4"

--- a/src/polodb/main.rs
+++ b/src/polodb/main.rs
@@ -24,7 +24,6 @@ static CONN_COUNT: AtomicI32 = AtomicI32::new(0);
 error_chain! {
 
     foreign_links {
-        Bson( polodb_bson::BsonErr);
         Db( polodb_core::DbErr);
         Fmt(::std::fmt::Error);
         Io(::std::io::Error);

--- a/src/polodb_core/backend/file/journal_manager.rs
+++ b/src/polodb_core/backend/file/journal_manager.rs
@@ -634,6 +634,7 @@ mod tests {
     use crate::page::RawPage;
     use crate::TransactionType;
     use crate::backend::file::journal_manager::JournalManager;
+    use crate::test_utils::mk_journal_path;
 
     static TEST_PAGE_LEN: u32 = 100;
 
@@ -648,15 +649,6 @@ mod tests {
         }
 
         page
-    }
-
-    fn mk_journal_path(db_name: &str) -> PathBuf {
-        let mut journal_path = env::temp_dir();
-
-        let journal_filename = String::from(db_name) + ".db.journal";
-        journal_path.push(journal_filename);
-
-        journal_path
     }
 
     fn prepare_journal_path(db_name: &str) -> String {

--- a/src/polodb_core/db.rs
+++ b/src/polodb_core/db.rs
@@ -1145,6 +1145,10 @@ mod tests {
             let db2 = Database::open_file_with_config(db_path.as_path().to_str().unwrap(), config);
             match db2 {
                 Err(DbErr::DatabaseOccupied) => assert!(true),
+                Err(other_error) => {
+                    println!("{:?}", other_error);
+                    assert!(false);
+                }
                 _ => assert!(false),
             }
         }

--- a/src/polodb_core/db.rs
+++ b/src/polodb_core/db.rs
@@ -276,7 +276,8 @@ impl<'a, T>  Collection<'a, T>
 /// use polodb_core::Database;
 /// use polodb_core::bson::{Document, doc};
 ///
-/// let mut db = Database::open_file("/tmp/test-polo.db").unwrap();
+/// # let db_path = polodb_core::test_utils::mk_db_path("doc-test-polo-db");
+/// let mut db = Database::open_file(db_path).unwrap();
 /// let mut collection = db.collection::<Document>("books");
 ///
 /// let docs = vec![
@@ -768,24 +769,9 @@ mod tests {
     use std::fs::File;
     use serde::{Deserialize, Serialize};
     use crate::db::Collection;
+    use crate::test_utils::{mk_db_path, mk_journal_path};
 
     static TEST_SIZE: usize = 1000;
-
-    fn mk_db_path(db_name: &str) -> PathBuf {
-        let mut db_path = env::temp_dir();
-        let db_filename = String::from(db_name) + ".db";
-        db_path.push(db_filename);
-        db_path
-    }
-
-    fn mk_journal_path(db_name: &str) -> PathBuf {
-        let mut journal_path = env::temp_dir();
-
-        let journal_filename = String::from(db_name) + ".db.journal";
-        journal_path.push(journal_filename);
-
-        journal_path
-    }
 
     fn prepare_db_with_config(db_name: &str, config: Config) -> DbResult<Database> {
         let db_path = mk_db_path(db_name);

--- a/src/polodb_core/lib.rs
+++ b/src/polodb_core/lib.rs
@@ -23,7 +23,8 @@
 //! use polodb_core::Database;
 //! use polodb_core::bson::doc;
 //!
-//! let mut db = Database::open_file("/tmp/test-collection").unwrap();
+//! # let db_path = polodb_core::test_utils::mk_db_path("doc-test-polo-lib");
+//! let mut db = Database::open_file(db_path).unwrap();
 //! let mut collection = db.collection("test");
 //! collection.insert_one(doc! {
 //!     "_id": 0,
@@ -74,6 +75,7 @@ mod doc_serializer;
 pub mod msg_ty;
 mod bson_utils;
 pub mod results;
+pub mod test_utils;
 
 pub use db::{Database, DbResult};
 pub use config::Config;

--- a/src/polodb_core/test_utils.rs
+++ b/src/polodb_core/test_utils.rs
@@ -1,0 +1,19 @@
+use std::path::PathBuf;
+use std::env;
+
+pub fn mk_db_path(db_name: &str) -> PathBuf {
+
+    let mut db_path = env::temp_dir();
+    let db_filename = String::from(db_name) + ".db";
+    db_path.push(db_filename);
+    db_path
+}
+
+pub fn mk_journal_path(db_name: &str) -> PathBuf {
+    let mut journal_path = env::temp_dir();
+
+    let journal_filename = String::from(db_name) + ".db.journal";
+    journal_path.push(journal_filename);
+
+    journal_path
+}


### PR DESCRIPTION
Abandon the `LockFilxEx` method on Windows.
Use the share flag to avoid other programs opening the database file.